### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/job-service-contract/pom.xml
+++ b/job-service-contract/pom.xml
@@ -27,6 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>job-service-contract</artifactId>
+    <name>job-service-contract</name>
 
     <properties>
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210